### PR TITLE
[FEAT] 서울 실시간 도시데이터 api - 인구 데이터에 인구 예측 지표도 함께 가져오기

### DIFF
--- a/src/main/java/com/example/whatseoul/dto/CityData.java
+++ b/src/main/java/com/example/whatseoul/dto/CityData.java
@@ -1,6 +1,7 @@
 package com.example.whatseoul.dto;
 
 import com.example.whatseoul.entity.Population;
+import com.example.whatseoul.entity.PopulationForecast;
 import com.example.whatseoul.entity.Weather;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,4 +11,5 @@ import lombok.Getter;
 public class CityData {
     private Weather weather;
     private Population population;
+    private PopulationForecast pplForecast;
 }

--- a/src/main/java/com/example/whatseoul/dto/CityData.java
+++ b/src/main/java/com/example/whatseoul/dto/CityData.java
@@ -1,5 +1,7 @@
 package com.example.whatseoul.dto;
 
+import java.util.List;
+
 import com.example.whatseoul.entity.Population;
 import com.example.whatseoul.entity.PopulationForecast;
 import com.example.whatseoul.entity.Weather;
@@ -11,5 +13,5 @@ import lombok.Getter;
 public class CityData {
     private Weather weather;
     private Population population;
-    private PopulationForecast pplForecast;
+    private List<PopulationForecast> pplForecast;
 }

--- a/src/main/java/com/example/whatseoul/entity/CultureEvent.java
+++ b/src/main/java/com/example/whatseoul/entity/CultureEvent.java
@@ -27,7 +27,7 @@ public class CultureEvent {
     @Column(name = "CULTURAL_EVENT_URL")
     private String culturalEventUrl;
 
-    @OneToOne
-    @JoinColumn(name = "AREA_CODE")
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "AREA_CODE", referencedColumnName = "AREA_CODE")
     private Area area;
 }

--- a/src/main/java/com/example/whatseoul/entity/Population.java
+++ b/src/main/java/com/example/whatseoul/entity/Population.java
@@ -19,8 +19,8 @@ public class Population {
     @Column(name = "POPULATION_ID")
     private Long populationId;
 
-    @OneToOne
-    @JoinColumn(name = "AREA_CODE")
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "AREA_CODE", referencedColumnName = "AREA_CODE")
     private Area area;
 
     // 장소 혼잡도 지표

--- a/src/main/java/com/example/whatseoul/entity/PopulationForecast.java
+++ b/src/main/java/com/example/whatseoul/entity/PopulationForecast.java
@@ -18,7 +18,7 @@ public class PopulationForecast {
     private Long forecastId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "POPULATION_ID")
+    @JoinColumn(name = "POPULATION_ID", referencedColumnName = "POPULATION_ID")
     private Population population;
 
     // 인구 혼잡도 예측 시점

--- a/src/main/java/com/example/whatseoul/entity/Weather.java
+++ b/src/main/java/com/example/whatseoul/entity/Weather.java
@@ -48,6 +48,6 @@ public class Weather {
     private String weatherTime;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "AREA_CODE")
+    @JoinColumn(name = "AREA_CODE", referencedColumnName = "AREA_CODE")
     private Area area;
 }

--- a/src/main/java/com/example/whatseoul/respository/cityData/PopulationForecastRepository.java
+++ b/src/main/java/com/example/whatseoul/respository/cityData/PopulationForecastRepository.java
@@ -1,0 +1,8 @@
+package com.example.whatseoul.respository.cityData;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.whatseoul.entity.PopulationForecast;
+
+public interface PopulationForecastRepository extends JpaRepository<PopulationForecast, Long> {
+}

--- a/src/main/java/com/example/whatseoul/service/ApiScheduler.java
+++ b/src/main/java/com/example/whatseoul/service/ApiScheduler.java
@@ -178,26 +178,27 @@ public class ApiScheduler {
         } else return "No Tag";
     }
 
-    private String getPplForecastText(Document document, String tag) {
-        NodeList nodeList = document.getElementsByTagName("FCST_PPLTN"); // 13개 노드가 담긴 리스트 반환, 0번 노드는 부모 노드
-        for (int i = 1; i < nodeList.getLength(); i++) {
-            Node fcstPpltnNode = nodeList.item(i);
-            NodeList childNodes = fcstPpltnNode.getChildNodes();
-
-            for (int j = 0; j < childNodes.getLength(); j++) {
-                Node childNode = childNodes.item(j);
-                if (childNode.getNodeName().equals(tag)) {
-                    return childNode.getTextContent();
-                }
-            }
-            // if (tag.equals("FCST_TIME")) {
-            //     return fcstPpltnNode.getFirstChild().getFirstChild().getTextContent();
-            // } else if (tag.equals("FCST_CONGEST_LVL")) {
-            //     return fcstPpltnNode.getFirstChild().getFirstChild().getNextSibling().getTextContent();
-            // }
-        }
-        return "No Tag";
-    }
+    // 향후 사용할 일이 없어보이면 삭제하겠습니다!
+    // private String getPplForecastText(Document document, String tag) {
+    //     NodeList nodeList = document.getElementsByTagName("FCST_PPLTN"); // 13개 노드가 담긴 리스트 반환, 0번 노드는 부모 노드
+    //     for (int i = 1; i < nodeList.getLength(); i++) {
+    //         Node fcstPpltnNode = nodeList.item(i);
+    //         NodeList childNodes = fcstPpltnNode.getChildNodes();
+    //
+    //         for (int j = 0; j < childNodes.getLength(); j++) {
+    //             Node childNode = childNodes.item(j);
+    //             if (childNode.getNodeName().equals(tag)) {
+    //                 return childNode.getTextContent();
+    //             }
+    //         }
+    //         // if (tag.equals("FCST_TIME")) {
+    //         //     return fcstPpltnNode.getFirstChild().getFirstChild().getTextContent();
+    //         // } else if (tag.equals("FCST_CONGEST_LVL")) {
+    //         //     return fcstPpltnNode.getFirstChild().getFirstChild().getNextSibling().getTextContent();
+    //         // }
+    //     }
+    //     return "No Tag";
+    // }
 }
 
 

--- a/src/main/java/com/example/whatseoul/service/ApiScheduler.java
+++ b/src/main/java/com/example/whatseoul/service/ApiScheduler.java
@@ -3,8 +3,10 @@ package com.example.whatseoul.service;
 import com.example.whatseoul.dto.CityData;
 import com.example.whatseoul.entity.Area;
 import com.example.whatseoul.entity.Population;
+import com.example.whatseoul.entity.PopulationForecast;
 import com.example.whatseoul.entity.Weather;
 import com.example.whatseoul.respository.cityData.AreaRepository;
+import com.example.whatseoul.respository.cityData.PopulationForecastRepository;
 import com.example.whatseoul.respository.cityData.PopulationRepository;
 import com.example.whatseoul.respository.cityData.WeatherRepository;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +16,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.w3c.dom.Document;
+import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
@@ -32,13 +35,14 @@ public class ApiScheduler {
     private final AreaRepository areaRepository;
     private final WeatherRepository weatherRepository;
     private final PopulationRepository populationRepository;
+    private final PopulationForecastRepository populationForecastRepository;
 
     @Value("${seoul.open.api.url}")
     private String url;
 
 
     @Transactional
-    @Scheduled(cron = "0 35/5 * * * *")
+    @Scheduled(cron = "0 34/5 * * * *")
     public void call() {
         long startTime = System.currentTimeMillis();
         List<Area> areas = areaRepository.findAll();
@@ -59,11 +63,19 @@ public class ApiScheduler {
                 .map(CityData::getPopulation) // WeatherAndPopulation에서 Population을 추출
                 .toList();
 
+        List<PopulationForecast> pplForecastList = allFutures.stream()
+            .map(CompletableFuture::join)
+            .map(CityData::getPplForecast)
+            .collect(Collectors.toList());
+
         weatherRepository.deleteAllInBatch();
         weatherRepository.saveAll(weatherList);
 
+        populationForecastRepository.deleteAllInBatch(); // 인구예측데이터를 먼저 삭제한 이후 인구 데이터 삭제
         populationRepository.deleteAllInBatch();
-        populationRepository.saveAll(populationList);
+        populationRepository.saveAll(populationList); // 인구데이터를 먼저 저장한 후 인구 예측 데이터 저장
+        populationForecastRepository.saveAll(pplForecastList);
+
 
         long endTime = System.currentTimeMillis();
         long totalTime = (endTime-startTime)/1000;
@@ -78,8 +90,9 @@ public class ApiScheduler {
                 Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(apiUrl);
                 Weather weather= parseWeatherData(document, area);
                 Population population = parsePopulationData(document, area);
+                PopulationForecast pplForecast = parsePopulationForecastData(document, population);
 
-                return new CityData(weather, population);
+                return new CityData(weather, population, pplForecast);
             } catch (SAXException | IOException | ParserConfigurationException e) {
                 log.error("error fetching citydata for areaname {}", area.getAreaName(), e);
                 return null;
@@ -110,6 +123,14 @@ public class ApiScheduler {
                 .build();
     }
 
+    public PopulationForecast parsePopulationForecastData(Document document, Population population) {
+        return PopulationForecast.builder()
+            .population(population)
+            .forecastTime(getPplForecastText(document, "FCST_TIME"))
+            .forecastCongestionLevel(getPplForecastText(document, "FCST_CONGEST_LVL"))
+            .build();
+    }
+
     public Weather parseWeatherData(Document document, Area area){
         return Weather.builder()
                     .temperature(getElement(document, "TEMP"))
@@ -132,6 +153,27 @@ public class ApiScheduler {
             // 첫 번째로 발견된 요소의 텍스트 내용 반환
             return nodeList.item(0).getTextContent();
         } else return "No Tag";
+    }
+
+    private String getPplForecastText(Document document, String tag) {
+        NodeList nodeList = document.getElementsByTagName("FCST_PPLTN"); // 13개 노드가 담긴 리스트 반환, 0번 노드는 부모 노드
+        for (int i = 1; i < nodeList.getLength(); i++) {
+            Node fcstPpltnNode = nodeList.item(i);
+            NodeList childNodes = fcstPpltnNode.getChildNodes();
+
+            for (int j = 0; j < childNodes.getLength(); j++) {
+                Node childNode = childNodes.item(j);
+                if (childNode.getNodeName().equals(tag)) {
+                    return childNode.getTextContent();
+                }
+            }
+            // if (tag.equals("FCST_TIME")) {
+            //     return fcstPpltnNode.getFirstChild().getFirstChild().getTextContent();
+            // } else if (tag.equals("FCST_CONGEST_LVL")) {
+            //     return fcstPpltnNode.getFirstChild().getFirstChild().getNextSibling().getTextContent();
+            // }
+        }
+        return "No Tag";
     }
 }
 


### PR DESCRIPTION
## 구현사항
- population 테이블에 기본적인 인구지표를 저장하던 기존 코드에 이어, population_forecast 테이블에 115개 지역에 대한 향후 12시간의 인구 예측 지표를 모두 저장할 수 있도록 스케줄러를 수정합니다.
- 새로 저장하는 지표
  - 인구 예측값
  - 장소 예측 혼잡도 지표 