### PR TITLE
[FEAT] 앨런 실시간 응답 기능 구현

### DIFF
--- a/src/main/java/com/example/whatseoul/WhatSeoulApplication.java
+++ b/src/main/java/com/example/whatseoul/WhatSeoulApplication.java
@@ -3,9 +3,11 @@ package com.example.whatseoul;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(exclude = SecurityAutoConfiguration.class)
+@EnableJpaAuditing // JPA Auditing 활성화
+@SpringBootApplication(exclude = {SecurityAutoConfiguration.class})
 @EnableScheduling
 public class WhatSeoulApplication {
 

--- a/src/main/java/com/example/whatseoul/controller/AlanViewController.java
+++ b/src/main/java/com/example/whatseoul/controller/AlanViewController.java
@@ -11,4 +11,10 @@ public class AlanViewController {
 	public String alanPage() {
 		return "/alan/alan";
 	}
+
+	// 앨런 sse질의 답변 조회 html 간단 연동
+	@GetMapping("/alan/sse")
+	public String alanSsePage() {
+		return "/alan/alansse";
+	}
 }

--- a/src/main/java/com/example/whatseoul/controller/SseController.java
+++ b/src/main/java/com/example/whatseoul/controller/SseController.java
@@ -3,6 +3,7 @@ package com.example.whatseoul.controller;
 
 import com.example.whatseoul.dto.response.AlanResponseDto;
 import com.example.whatseoul.service.WebClientService;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -10,6 +11,8 @@ import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Flux;
+
+import java.time.Duration;
 
 @RequiredArgsConstructor
 @RestController
@@ -22,7 +25,8 @@ public class SseController {
     private String alanId;
 
     @GetMapping("/alan")
-    public Flux<ServerSentEvent<AlanResponseDto>> getAlanResponse(){
+    public Flux<ServerSentEvent<AlanResponseDto>> getAlanResponse(HttpServletResponse response){
+        response.setContentType("text/event-stream");
         return webClientService.getResponse()
                 .doOnNext(data -> {
                     // 받은 데이터를 로그로 출력
@@ -32,6 +36,7 @@ public class SseController {
                         .id("eventId")
                         .event("eventType")
                         .data(data)
-                        .build());
+                        .build())
+                .delayElements(Duration.ofMillis(50));
     }
 }

--- a/src/main/java/com/example/whatseoul/controller/SseController.java
+++ b/src/main/java/com/example/whatseoul/controller/SseController.java
@@ -9,6 +9,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Flux;
 
@@ -16,6 +18,7 @@ import java.time.Duration;
 
 @RequiredArgsConstructor
 @RestController
+@RequestMapping("/api")
 @Slf4j
 public class SseController {
 
@@ -25,16 +28,13 @@ public class SseController {
     private String alanId;
 
     @GetMapping("/alan")
-    public Flux<ServerSentEvent<AlanResponseDto>> getAlanResponse(HttpServletResponse response){
+    public Flux<ServerSentEvent<AlanResponseDto>> getAlanResponse(HttpServletResponse response, @RequestParam String content){
         response.setContentType("text/event-stream");
-        return webClientService.getResponse()
+        return webClientService.getResponse(content)
                 .doOnNext(data -> {
-                    // 받은 데이터를 로그로 출력
                     log.info("Received data: {}", data.getData().getContent());
                 })
                 .map(data -> ServerSentEvent.<AlanResponseDto>builder()
-                        .id("eventId")
-                        .event("eventType")
                         .data(data)
                         .build())
                 .delayElements(Duration.ofMillis(50));

--- a/src/main/java/com/example/whatseoul/controller/SseController.java
+++ b/src/main/java/com/example/whatseoul/controller/SseController.java
@@ -24,9 +24,6 @@ public class SseController {
 
     private final WebClientService webClientService;
 
-    @Value("${alan.key}")
-    private String alanId;
-
     @GetMapping("/alan")
     public Flux<ServerSentEvent<AlanResponseDto>> getAlanResponse(HttpServletResponse response, @RequestParam String content){
         response.setContentType("text/event-stream");

--- a/src/main/java/com/example/whatseoul/controller/SseController.java
+++ b/src/main/java/com/example/whatseoul/controller/SseController.java
@@ -24,6 +24,10 @@ public class SseController {
     @GetMapping("/alan")
     public Flux<ServerSentEvent<AlanResponseDto>> getAlanResponse(){
         return webClientService.getResponse()
+                .doOnNext(data -> {
+                    // 받은 데이터를 로그로 출력
+                    log.info("Received data: {}", data.getData().getContent());
+                })
                 .map(data -> ServerSentEvent.<AlanResponseDto>builder()
                         .id("eventId")
                         .event("eventType")

--- a/src/main/java/com/example/whatseoul/service/AlanService.java
+++ b/src/main/java/com/example/whatseoul/service/AlanService.java
@@ -21,7 +21,7 @@ import lombok.extern.slf4j.Slf4j;
 public class AlanService {
 	private static final String BASE_URL = "https://kdt-api-function.azurewebsites.net/api/v1/question";
 
-	@Value("${alan.api.client_id}")
+	@Value("${alan.key}")
 	private String CLIENT_ID;
 	private final RestTemplate restTemplate;
 	private final ObjectMapper objectMapper;

--- a/src/main/java/com/example/whatseoul/service/ApiScheduler.java
+++ b/src/main/java/com/example/whatseoul/service/ApiScheduler.java
@@ -39,7 +39,7 @@ public class ApiScheduler {
 
 
     @Transactional
-    @Scheduled(cron = "0 33/5 * * * *")
+    @Scheduled(cron = "0 46/5 * * * *")
     public void call() {
         long startTime = System.currentTimeMillis();
         List<Area> areas = areaRepository.findAll();

--- a/src/main/java/com/example/whatseoul/service/WebClientService.java
+++ b/src/main/java/com/example/whatseoul/service/WebClientService.java
@@ -25,7 +25,7 @@ public class WebClientService {
         return webClient.get()
                 .uri("https://kdt-api-function.azurewebsites.net/api/v1/question/sse-streaming",
                         uriBuilder -> uriBuilder
-                        .queryParam("content", "red")
+                        .queryParam("content", "서울의 명소를 추천해줄래?")
                         .queryParam("client_id", alanId)
                         .build())
                 .retrieve()

--- a/src/main/java/com/example/whatseoul/service/WebClientService.java
+++ b/src/main/java/com/example/whatseoul/service/WebClientService.java
@@ -21,11 +21,11 @@ public class WebClientService {
     private final WebClient webClient = WebClient.builder().build();
     private final ObjectMapper objectMapper = new ObjectMapper().configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, true);
 
-    public Flux<AlanResponseDto> getResponse(){
+    public Flux<AlanResponseDto> getResponse(String content){
         return webClient.get()
                 .uri("https://kdt-api-function.azurewebsites.net/api/v1/question/sse-streaming",
                         uriBuilder -> uriBuilder
-                        .queryParam("content", "서울의 명소를 추천해줄래?")
+                        .queryParam("content", content)
                         .queryParam("client_id", alanId)
                         .build())
                 .retrieve()
@@ -35,11 +35,10 @@ public class WebClientService {
 
     private Flux<AlanResponseDto> parseJsonToResponseDto(String jsonString){
         try {
-            // Parse JSON string to ResponseDto object
+            // JSON 문자열을 ResponseDto 객체로 파싱
             AlanResponseDto responseDto = this.objectMapper.readValue(jsonString, AlanResponseDto.class);
             return Flux.just(responseDto);
         } catch (JsonProcessingException e) {
-            // Handle parsing exception
             return Flux.error(e);
         }
     }

--- a/src/main/java/com/example/whatseoul/service/WebClientService.java
+++ b/src/main/java/com/example/whatseoul/service/WebClientService.java
@@ -18,7 +18,6 @@ public class WebClientService {
 
     @Value("${alan.key}")
     private String alanId;
-
     private final WebClient webClient = WebClient.builder().build();
     private final ObjectMapper objectMapper = new ObjectMapper().configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, true);
 

--- a/src/main/resources/static/js/alan/alansse.js
+++ b/src/main/resources/static/js/alan/alansse.js
@@ -1,0 +1,49 @@
+const alanResponse = document.querySelector('#alanResponse');
+
+// 서버로부터 SSE를 수신하는 함수
+function setupSSE() {
+    const eventSource = new EventSource('/alan',
+        {
+            withCredentials: true,
+        });// /alans 엔드포인트로 SSE 요청
+    eventSource.onopen = (e) => {
+        console.log(e);
+        console.log(e.data);
+        console.log("onopen");
+    }
+    eventSource.onmessage = (e) => {
+        console.log(e);
+        console.log(e.data);
+        console.log("onmessage")
+    }
+    eventSource.addEventListener('ping', (e) => {
+        console.log(ping);
+    })
+    eventSource.addEventListener('open', (e) => {
+        console.log('SSE 연결이 열렸습니다.');
+    });
+
+    eventSource.addEventListener('message', (event) => {
+        console.log(event);
+        console.log(event.data);
+        // 받은 데이터를 화면에 추가
+        alanResponse.textContent += event.data;
+    });
+
+    eventSource.addEventListener('complete', (e) => {
+        console.log(e);
+        console.log("complete");
+    })
+
+    eventSource.onerror = (error) => {
+        console.error('SSE Error:', error);
+        eventSource.close(); // 에러 발생 시 연결 종료
+    };
+};
+
+document.addEventListener('DOMContentLoaded', function () {
+    console.log("앨런의 답변 기다리는중..");
+    alanResponse.innerHTML = "앨런의 답변 기다리는중..(새로고침하면 처음부터 다시 호출해버린답니다ㅠ))";
+
+    setupSSE(); // SSE 설정 및 수신 시작
+});

--- a/src/main/resources/static/js/alan/alansse.js
+++ b/src/main/resources/static/js/alan/alansse.js
@@ -32,6 +32,7 @@ function setupSSE(question) {
         }); // /alan 엔드포인트로 SSE 요청
     eventSource.onopen = (e) => {
         console.log("onopen");
+        alanResponse.innerHTML = "";
         console.log(question);
     }
 
@@ -46,14 +47,14 @@ function setupSSE(question) {
         const speak = parsedData.data.speak; // data -> data -> speak 접근
 
         if (type === "action") {
-            alanResponse.innerHTML += "<br><br>" + formatResponse(speak) + "<br><br>";
+            alanResponse.innerHTML += speak + "<br><br>";
             console.log(speak);
         } else if (type === "continue") {
-            alanResponse.innerHTML += formatResponse(content);
+            alanResponse.innerHTML += content;
             console.log(content);
         } else if (type === "complete") {
             alanResponse.innerHTML = "";
-            alanResponse.innerHTML = formatResponse(content);
+            alanResponse.innerHTML = "정보 확인이 완료되었습니다.<br><br>" + formatResponse(content);
             console.log(content);
         }
     }

--- a/src/main/resources/static/js/alan/alansse.js
+++ b/src/main/resources/static/js/alan/alansse.js
@@ -1,34 +1,38 @@
+const form = document.querySelector("#questionForm");
+const input = document.querySelector("#question");
+
+form.addEventListener("submit", function(event) {
+    event.preventDefault(); // 새로고침 방지
+    alanResponse.innerHTML = "앨런의 답변 기다리는중..(새로고침하면 처음부터 다시 호출해버린답니다ㅠ))";
+    const question = input.value;
+    console.log(question);
+
+    setupSSE(question); // SSE 설정 및 수신 시작
+
+})
 const alanResponse = document.querySelector('#alanResponse');
 
 // 서버로부터 SSE를 수신하는 함수
-function setupSSE() {
-    const eventSource = new EventSource('/alan',
+function setupSSE(question) {
+    const eventSource = new EventSource(`/api/alan?content=${question}`,
         {
             withCredentials: true,
-        });// /alans 엔드포인트로 SSE 요청
+        }); // /alan 엔드포인트로 SSE 요청
     eventSource.onopen = (e) => {
-        console.log(e);
-        console.log(e.data);
         console.log("onopen");
+        console.log(question);
     }
+
     eventSource.onmessage = (e) => {
+        console.log("onmessage")
         console.log(e);
         console.log(e.data);
-        console.log("onmessage")
+        console.log(typeof e.data); // string
+        const parsedData = JSON.parse(e.data);
+        const content = parsedData.data.content; // data -> data -> content 접근
+        console.log(content);
+        alanResponse.textContent += content;
     }
-    eventSource.addEventListener('ping', (e) => {
-        console.log(ping);
-    })
-    eventSource.addEventListener('open', (e) => {
-        console.log('SSE 연결이 열렸습니다.');
-    });
-
-    eventSource.addEventListener('message', (event) => {
-        console.log(event);
-        console.log(event.data);
-        // 받은 데이터를 화면에 추가
-        alanResponse.textContent += event.data;
-    });
 
     eventSource.addEventListener('complete', (e) => {
         console.log(e);
@@ -39,11 +43,11 @@ function setupSSE() {
         console.error('SSE Error:', error);
         eventSource.close(); // 에러 발생 시 연결 종료
     };
-};
+}
 
-document.addEventListener('DOMContentLoaded', function () {
-    console.log("앨런의 답변 기다리는중..");
-    alanResponse.innerHTML = "앨런의 답변 기다리는중..(새로고침하면 처음부터 다시 호출해버린답니다ㅠ))";
-
-    setupSSE(); // SSE 설정 및 수신 시작
-});
+// document.addEventListener('DOMContentLoaded', function () {
+//     console.log("앨런의 답변 기다리는중..");
+//     alanResponse.innerHTML = "앨런의 답변 기다리는중..(새로고침하면 처음부터 다시 호출해버린답니다ㅠ))";
+//
+//     setupSSE(); // SSE 설정 및 수신 시작
+// });

--- a/src/main/resources/static/js/alan/alansse.js
+++ b/src/main/resources/static/js/alan/alansse.js
@@ -30,8 +30,14 @@ function setupSSE(question) {
         console.log(typeof e.data); // string
         const parsedData = JSON.parse(e.data);
         const content = parsedData.data.content; // data -> data -> content 접근
-        console.log(content);
-        alanResponse.textContent += content;
+        const speak = parsedData.data.speak; // data -> data -> speak 접근
+        if(content == null) {
+            alanResponse.textContent += speak;
+            console.log(speak);
+        } else {
+            alanResponse.textContent += content;
+            console.log(content);
+        }
     }
 
     eventSource.addEventListener('complete', (e) => {

--- a/src/main/resources/templates/alan/alansse.html
+++ b/src/main/resources/templates/alan/alansse.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Title</title>
+    <title>WhatSeoul</title>
     <script defer src="/js/alan/alansse.js"></script>
 
 </head>

--- a/src/main/resources/templates/alan/alansse.html
+++ b/src/main/resources/templates/alan/alansse.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+    <script defer src="/js/alan/alansse.js"></script>
+
+</head>
+<body>
+<div id="alanResponse"></div>
+
+
+</body>
+</html>

--- a/src/main/resources/templates/alan/alansse.html
+++ b/src/main/resources/templates/alan/alansse.html
@@ -7,6 +7,12 @@
 
 </head>
 <body>
+<form id="questionForm">
+    <label for="question">
+        <input id="question" name="question" type="text" placeholder="앨런에게 질문을 남겨보세요.">
+    </label>
+    <button type="submit">질문하기</button>
+</form>
 <div id="alanResponse"></div>
 
 


### PR DESCRIPTION
## 구현 사항
- 앨런 ai의 sse api 응답 스트림의 내부 데이터를 50 ms 간격으로 받아오고, html상에 sse 요청의 응답값을 순서대로 누적해 보여주도록 합니다

## 캡쳐
- 앨런 ai 응답 대기에 30초.. 응답 모두 출력에 30초 정도 걸리는 듯 해 보시기 편하게 영상도 올립니다 ☠
    - https://www.youtube.com/watch?v=kq3qr_f89Rc
    - 8초~대략 34초까지는 질문을 입력하고 앨런 ai의 응답을 계속 기다리는 중이라 멈춰있는것처럼 보일 수 있습니다ㅠㅠ
     
- ✅api url :`~/api/alan?content={content}`

단순 input에 
![image](https://github.com/WhatSEOUL/WhatSeoul/assets/82032418/272e5343-b179-4f32-be2e-71ea32571f92)

질문을 적어 보내면
![image](https://github.com/WhatSEOUL/WhatSeoul/assets/82032418/05a7d371-f7a9-4fe0-9a24-0b093b4d1687)

이렇게 볼드처리를 하거나 클릭하면 링크로 이동할 수 있게 하기위한 스멜이 나는 흔적이 있는 텍스트가 순서대로 받아와집니다
![image](https://github.com/WhatSEOUL/WhatSeoul/assets/82032418/9a9d10a0-795a-4d87-8271-a619a441408a)

인내심을 가지고 기다리면.. 볼드처리랑 링크처리를 마친 답이 완성됩니다
![image](https://github.com/WhatSEOUL/WhatSeoul/assets/82032418/524de07c-499d-46ea-8053-3ad8e7abee99)

## todo
- [ ] SSE error 해결
    - 처음부터.. 그리고 지금까지도  꼭 EventSource 메시지 수신을 마치면 complete([여기](https://github.com/WhatSEOUL/WhatSeoul/pull/38/files#:~:text=eventSource.addEventListener,%7D))로 빠지지를 않고 error([여기](https://github.com/WhatSEOUL/WhatSeoul/pull/38/files#:~:text=eventSource.onerror,%7D%3B))로 빠지고 있는데 아직 응답을 출력하는 것 자체에는 문제는 없지만 혹시 몰라 수정해보겠습니다..
- [x] 다른 페이지와 유사하게 ui 수정
- [x] 앨런 ai 응답이 도착하지 않아서 eventSource가 open되기 전까지 로딩중인걸 더 가시적으로 보여주기?